### PR TITLE
Add pre-commit hooks for ktlint checking

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+# Pre-commit hook to run ktlintCheck before each commit
+echo "Running ktlint check..."
+
+# Run ktlintCheck
+./gradlew ktlintCheck
+
+# Check if ktlintCheck passed
+if [ $? -ne 0 ]; then
+    echo "❌ ktlint check failed. Please fix formatting issues before committing."
+    echo "You can run './gradlew ktlintFormat' to auto-fix most issues."
+    exit 1
+fi
+
+echo "✅ ktlint check passed!"
+exit 0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,10 +6,23 @@ This file contains important context and configuration for Claude Code to unders
 Tomaten - A Pomodoro timer application
 
 ## Development Commands
-- Build: (to be added)
-- Test: (to be added)  
-- Lint: (to be added)
-- Type check: (to be added)
+- Build: `./gradlew build`
+- Test: `./gradlew test`  
+- Lint: `./gradlew lint`
+- Ktlint check: `./gradlew ktlintCheck`
+- Ktlint format: `./gradlew ktlintFormat`
+
+## Git Hooks Setup
+To enable pre-commit ktlint checking for all contributors:
+
+```bash
+# Set up git hooks directory
+git config core.hooksPath .githooks
+```
+
+This will run `./gradlew ktlintCheck` before each commit and prevent commits with formatting issues.
 
 ## Important Notes
-- (to be added based on project needs)
+- Pre-commit hook runs ktlint check automatically
+- Use `./gradlew ktlintFormat` to fix formatting issues
+- CI runs tests, lint, and ktlint checks in parallel


### PR DESCRIPTION
## Summary
- Add reusable pre-commit hook script to enforce ktlint formatting
- Update project documentation with setup instructions and development commands
- Enable consistent code quality across all contributors

## Changes Made
- **`.githooks/pre-commit`**: Pre-commit script that runs `./gradlew ktlintCheck`
  - Blocks commits if ktlint formatting issues are found
  - Provides helpful feedback with fix suggestions
  - Executable and ready to use
- **`CLAUDE.md`**: Updated with comprehensive development information
  - Added all Gradle commands (build, test, lint, ktlint)
  - Included git hooks setup instructions
  - Added important notes about pre-commit workflow

## Setup Instructions
Contributors can enable the pre-commit hook by running:
```bash
git config core.hooksPath .githooks
```

## Benefits
- **Consistent Formatting**: Ensures all commits follow ktlint standards
- **Early Detection**: Catches formatting issues before CI/code review
- **Developer Experience**: Clear feedback and auto-fix suggestions
- **Team Productivity**: Reduces back-and-forth in code reviews

## Test Plan
- [x] Pre-commit hook runs ktlintCheck successfully
- [x] Hook blocks commits with formatting issues
- [x] Hook allows commits when code passes ktlint standards
- [x] Documentation includes clear setup instructions

🤖 Generated with [Claude Code](https://claude.ai/code)