### PR TITLE
Add timer service with foreground notifications

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,9 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
     <uses-permission android:name="android.permission.VIBRATE" />
 
     <application
@@ -15,10 +18,14 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.Tomaten"
         tools:targetApi="31">
+
+        <meta-data
+            android:name="firebase_performance_logcat_enabled"
+            android:value="true" />
+
         <activity
             android:name=".MainActivity"
             android:exported="true"
-            android:label="@string/app_name"
             android:theme="@style/Theme.Tomaten">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
@@ -26,6 +33,17 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
+        <service
+            android:name=".services.TimerService"
+            android:externalService="false"
+            android:foregroundServiceType="shortService">
+
+            <property
+                android:name="android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE"
+                android:value="Timer" />
+
+        </service>
     </application>
 
 </manifest>

--- a/app/src/main/java/io/github/hanihashemi/tomaten/MainActivity.kt
+++ b/app/src/main/java/io/github/hanihashemi/tomaten/MainActivity.kt
@@ -103,7 +103,7 @@ class MainActivity : ComponentActivity() {
                     context: Context?,
                     intent: Intent?,
                 ) {
-                    val remainingTime = intent?.getIntExtra(REMAINING_TIME, 0) ?: 0
+                    val remainingTime = intent?.getLongExtra(REMAINING_TIME, 0) ?: 0
                     viewModel.actions.timer.updateTimer(remainingTime)
                 }
             }

--- a/app/src/main/java/io/github/hanihashemi/tomaten/MainActivity.kt
+++ b/app/src/main/java/io/github/hanihashemi/tomaten/MainActivity.kt
@@ -1,16 +1,28 @@
 package io.github.hanihashemi.tomaten
 
+import android.Manifest
+import android.app.ActivityManager
+import android.app.AlertDialog
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.content.pm.PackageManager
+import android.os.Build
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.runtime.LaunchedEffect
+import androidx.core.content.ContextCompat
 import androidx.credentials.Credential
 import androidx.credentials.CredentialManager
 import androidx.credentials.CustomCredential
 import androidx.credentials.GetCredentialRequest
 import androidx.credentials.exceptions.GetCredentialException
 import androidx.lifecycle.lifecycleScope
+import androidx.localbroadcastmanager.content.LocalBroadcastManager
 import com.google.android.libraries.identity.googleid.GetGoogleIdOption
 import com.google.android.libraries.identity.googleid.GoogleIdTokenCredential
 import com.google.android.libraries.identity.googleid.GoogleIdTokenCredential.Companion.TYPE_GOOGLE_ID_TOKEN_CREDENTIAL
@@ -18,6 +30,10 @@ import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.GoogleAuthProvider
 import com.google.firebase.auth.ktx.auth
 import com.google.firebase.ktx.Firebase
+import io.github.hanihashemi.tomaten.services.TimerService
+import io.github.hanihashemi.tomaten.services.TimerService.Companion.REMAINING_TIME
+import io.github.hanihashemi.tomaten.services.TimerService.Companion.TIME_PARAM
+import io.github.hanihashemi.tomaten.services.TimerService.Companion.TIME_UPDATE_ACTION
 import io.github.hanihashemi.tomaten.theme.TomatenTheme
 import io.github.hanihashemi.tomaten.ui.events.UiEvents
 import io.github.hanihashemi.tomaten.ui.screens.main.MainScreen
@@ -28,10 +44,24 @@ import org.koin.androidx.viewmodel.ext.android.viewModel
 class MainActivity : ComponentActivity() {
     private val viewModel: MainViewModel by viewModel()
     private lateinit var auth: FirebaseAuth
+    private lateinit var timerUpdateReceiver: BroadcastReceiver
+    private var timeLimit: Long = 0
+
+    private val requestPermissionLauncher =
+        registerForActivityResult(
+            ActivityResultContracts.RequestPermission(),
+        ) { isGranted: Boolean ->
+            if (isGranted) {
+                startTimerService(timeLimit)
+            } else {
+                showPermissionRationaleDialog()
+            }
+        }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
+        listenToTimerService()
         setContent {
             TomatenTheme {
                 LaunchedEffect(Unit) {
@@ -44,42 +74,92 @@ class MainActivity : ComponentActivity() {
         auth = Firebase.auth
     }
 
+    override fun onDestroy() {
+        super.onDestroy()
+        LocalBroadcastManager.getInstance(this).unregisterReceiver(timerUpdateReceiver)
+    }
+
     private suspend fun listenToUiEvents() {
         viewModel.uiEvents.collect { event ->
             when (event) {
-                is UiEvents.Login -> {
-                    val googleIdOption =
-                        GetGoogleIdOption.Builder()
-                            .setServerClientId(getString(R.string.default_web_client_id))
-                            .setFilterByAuthorizedAccounts(false)
-                            .build()
+                is UiEvents.Login -> login()
+                is UiEvents.StopTimer -> {
+                    val intent = Intent(this, TimerService::class.java)
+                    stopService(intent)
+                }
 
-                    val request =
-                        GetCredentialRequest.Builder()
-                            .addCredentialOption(googleIdOption)
-                            .build()
-
-                    val credentialManager = CredentialManager.create(this@MainActivity)
-                    lifecycleScope.launch(Dispatchers.IO) {
-                        try {
-                            val result =
-                                credentialManager.getCredential(
-                                    request = request,
-                                    context = this@MainActivity,
-                                )
-                            handleSignIn(result.credential)
-                        } catch (e: GetCredentialException) {
-                            if (e.message?.contains("16") == true || e.message?.contains("28433") == true) {
-                                viewModel.actions.login.setErrorMessage(
-                                    "No Google account found. Please sign in to your device and try again.",
-                                )
-                            } else {
-                                viewModel.actions.login.setErrorMessage("Sign-in failed: ${e.message}")
-                            }
-                        }
-                    }
+                is UiEvents.StartTimer -> {
+                    timeLimit = event.timeLimit
+                    askNotificationPermissionAndStartTimerService()
                 }
             }
+        }
+    }
+
+    private fun listenToTimerService() {
+        timerUpdateReceiver =
+            object : BroadcastReceiver() {
+                override fun onReceive(
+                    context: Context?,
+                    intent: Intent?,
+                ) {
+                    val remainingTime = intent?.getIntExtra(REMAINING_TIME, 0) ?: 0
+                    viewModel.actions.timer.updateTimer(remainingTime)
+                }
+            }
+
+        LocalBroadcastManager.getInstance(this).registerReceiver(
+            timerUpdateReceiver,
+            IntentFilter(TIME_UPDATE_ACTION),
+        )
+    }
+
+    private fun login() {
+        val googleIdOption =
+            GetGoogleIdOption.Builder()
+                .setServerClientId(getString(R.string.default_web_client_id))
+                .setFilterByAuthorizedAccounts(false)
+                .build()
+
+        val request =
+            GetCredentialRequest.Builder()
+                .addCredentialOption(googleIdOption)
+                .build()
+
+        val credentialManager = CredentialManager.create(this@MainActivity)
+        lifecycleScope.launch(Dispatchers.IO) {
+            try {
+                val result =
+                    credentialManager.getCredential(
+                        request = request,
+                        context = this@MainActivity,
+                    )
+                handleSignIn(result.credential)
+            } catch (e: GetCredentialException) {
+                if (e.message?.contains("16") == true || e.message?.contains("28433") == true) {
+                    viewModel.actions.login.setErrorMessage(
+                        "No Google account found. Please sign in to your device and try again.",
+                    )
+                } else {
+                    viewModel.actions.login.setErrorMessage("Sign-in failed: ${e.message}")
+                }
+            }
+        }
+    }
+
+    private fun askNotificationPermissionAndStartTimerService() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            val permission =
+                ContextCompat.checkSelfPermission(
+                    this@MainActivity,
+                    Manifest.permission.POST_NOTIFICATIONS,
+                )
+            when {
+                permission == PackageManager.PERMISSION_GRANTED -> startTimerService(timeLimit)
+                else -> requestPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
+            }
+        } else {
+            startTimerService(timeLimit)
         }
     }
 
@@ -114,5 +194,39 @@ class MainActivity : ComponentActivity() {
         } else {
             viewModel.actions.login.setErrorMessage(errorMessage = "Credential is not of type Google ID!")
         }
+    }
+
+    private fun startTimerService(timeLimit: Long) {
+        val intent =
+            Intent(this, TimerService::class.java).apply {
+                putExtra(TIME_PARAM, timeLimit)
+            }
+        startForegroundService(intent)
+    }
+
+    private fun showPermissionRationaleDialog() {
+        val title = "Notification Permission Needed"
+        val message =
+            "To keep the timer running in the background, please grant notification permission."
+        val positiveButton = "OK"
+
+        AlertDialog.Builder(this)
+            .setTitle(title)
+            .setMessage(message)
+            .setPositiveButton(positiveButton) { dialog, _ ->
+                dialog.dismiss()
+            }
+            .create()
+            .show()
+    }
+
+    private fun isTimerServiceRunning(): Boolean {
+        val activityManager = getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager
+        for (service in activityManager.getRunningServices(Int.MAX_VALUE)) {
+            if (TimerService::class.java.name == service.service.className) {
+                return true
+            }
+        }
+        return false
     }
 }

--- a/app/src/main/java/io/github/hanihashemi/tomaten/MainViewModel.kt
+++ b/app/src/main/java/io/github/hanihashemi/tomaten/MainViewModel.kt
@@ -31,7 +31,7 @@ open class MainViewModel : ViewModel() {
                 User(
                     name = user.displayName,
                     email = user.email,
-                    photoUrl = user.photoUrl.toString().orEmpty(),
+                    photoUrl = user.photoUrl.toString(),
                     uid = user.uid,
                 )
             updateState {

--- a/app/src/main/java/io/github/hanihashemi/tomaten/extensions/TimerExtension.kt
+++ b/app/src/main/java/io/github/hanihashemi/tomaten/extensions/TimerExtension.kt
@@ -1,0 +1,11 @@
+package io.github.hanihashemi.tomaten.extensions
+
+import java.util.Locale
+
+fun Long.formatTime(): String {
+    val minutes = this / 60
+    val remainingSeconds = this % 60
+    return String.format(Locale.getDefault(), "%d:%02d", minutes, remainingSeconds)
+}
+
+fun Int.toSeconds(): Long = (this * 60).toLong()

--- a/app/src/main/java/io/github/hanihashemi/tomaten/services/TimerService.kt
+++ b/app/src/main/java/io/github/hanihashemi/tomaten/services/TimerService.kt
@@ -41,6 +41,12 @@ class TimerService : Service() {
         createNotificationChannel()
     }
 
+    override fun onDestroy() {
+        super.onDestroy()
+        job?.cancel()
+        job = null
+    }
+
     override fun onStartCommand(
         intent: Intent?,
         flags: Int,

--- a/app/src/main/java/io/github/hanihashemi/tomaten/services/TimerService.kt
+++ b/app/src/main/java/io/github/hanihashemi/tomaten/services/TimerService.kt
@@ -1,0 +1,171 @@
+package io.github.hanihashemi.tomaten.services
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.app.Service
+import android.content.Intent
+import android.content.pm.ServiceInfo
+import android.os.Build
+import android.os.IBinder
+import androidx.core.app.NotificationCompat
+import androidx.core.app.ServiceCompat
+import androidx.localbroadcastmanager.content.LocalBroadcastManager
+import io.github.hanihashemi.tomaten.MainActivity
+import io.github.hanihashemi.tomaten.R
+import io.github.hanihashemi.tomaten.extensions.formatTime
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+class TimerService : Service() {
+    companion object {
+        const val TIME_PARAM = "startTime"
+        const val REMAINING_TIME = "remainingTime"
+        const val TIME_UPDATE_ACTION = "TIMER_UPDATED"
+        private const val CHANNEL = "TIMER_SERVICE_CHANNEL"
+    }
+
+    private var remainingTime: Long = 0
+    private var job: Job? = null
+
+    override fun onBind(intent: Intent?): IBinder? {
+        return null
+    }
+
+    override fun onCreate() {
+        super.onCreate()
+        createNotificationChannel()
+    }
+
+    override fun onStartCommand(
+        intent: Intent?,
+        flags: Int,
+        startId: Int,
+    ): Int {
+        startForeground()
+        val timeInMillis = intent?.getLongExtra(TIME_PARAM, 0) ?: 0
+        startTimer(timeInMillis)
+        return START_STICKY
+    }
+
+    private fun startForeground() {
+        val notificationContent = "Timer Started"
+        val notification = createNotification(notificationContent, 0, 0)
+        val notificationType =
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+                ServiceInfo.FOREGROUND_SERVICE_TYPE_SHORT_SERVICE
+            } else {
+                0
+            }
+
+        ServiceCompat.startForeground(
+            this@TimerService,
+            1,
+            notification,
+            notificationType,
+        )
+    }
+
+    private fun startTimer(timeInMillis: Long) {
+        println("==> startTimer: $timeInMillis")
+        remainingTime = timeInMillis
+        job =
+            CoroutineScope(Dispatchers.IO).launch {
+                while (remainingTime > 0) {
+                    val progress = timeInMillis - remainingTime
+                    val content = "Remaining Time: ${remainingTime.formatTime()}"
+
+                    sendTimeUpdate()
+                    updateNotification(
+                        content,
+                        progress.toInt(),
+                        timeInMillis.toInt(),
+                    )
+                    delay(1000) // delay for 1 second
+                    remainingTime -= 1
+                }
+                sendTimeUpdate()
+                showCompletionNotification()
+            }
+    }
+
+    private fun sendTimeUpdate() {
+        val intent = Intent(TIME_UPDATE_ACTION)
+        intent.putExtra(REMAINING_TIME, remainingTime)
+        LocalBroadcastManager.getInstance(this).sendBroadcast(intent)
+    }
+
+    private fun updateNotification(
+        content: String,
+        progress: Int = 0,
+        maxProgress: Int = 0,
+    ) {
+        val notification = createNotification(content, progress, maxProgress)
+        val notificationManager =
+            getSystemService(NOTIFICATION_SERVICE) as NotificationManager
+        notificationManager.notify(1, notification)
+    }
+
+    private fun createNotificationChannel() {
+        val serviceChannel =
+            NotificationChannel(
+                CHANNEL,
+                "Timer Service Channel",
+                NotificationManager.IMPORTANCE_DEFAULT,
+            )
+        val manager = getSystemService(NotificationManager::class.java)
+        manager.createNotificationChannel(serviceChannel)
+    }
+
+    private fun createNotification(
+        content: String,
+        progress: Int,
+        maxProgress: Int,
+    ): Notification {
+        val title = "Timer Service"
+        return NotificationCompat.Builder(this, CHANNEL)
+            .setContentTitle(title)
+            .setContentText(content)
+            .setContentIntent(
+                PendingIntent.getActivity(
+                    this,
+                    0,
+                    Intent(this, MainActivity::class.java),
+                    PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+                ),
+            )
+            .setSmallIcon(R.drawable.tomato)
+            .setProgress(maxProgress, progress, false)
+            .setSilent(true) // Don't play a sound
+            .build()
+    }
+
+    private fun showCompletionNotification() {
+        val title = "Timer Service"
+        val content = "Timer Completed"
+        val intent = Intent(this, MainActivity::class.java)
+        val pendingIntent =
+            PendingIntent.getActivity(
+                this,
+                0,
+                intent,
+                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+            )
+
+        val notification =
+            NotificationCompat.Builder(this, CHANNEL)
+                .setContentTitle(title)
+                .setContentText(content)
+                .setSmallIcon(R.drawable.tomato)
+                .setContentIntent(pendingIntent)
+                .build()
+
+        val notificationManager =
+            getSystemService(NOTIFICATION_SERVICE) as NotificationManager
+        notificationManager.notify(2, notification)
+    }
+}

--- a/app/src/main/java/io/github/hanihashemi/tomaten/ui/actions/Actions.kt
+++ b/app/src/main/java/io/github/hanihashemi/tomaten/ui/actions/Actions.kt
@@ -1,11 +1,64 @@
 package io.github.hanihashemi.tomaten.ui.actions
 
 import io.github.hanihashemi.tomaten.MainViewModel
+import io.github.hanihashemi.tomaten.ui.events.UiEvents
 
 class Actions(viewModel: MainViewModel) {
     val login = LoginAction(viewModel)
+    val timer = TimerAction(viewModel)
 }
 
 val previewActions = Actions(viewModel = FakeViewModel())
 
 class FakeViewModel : MainViewModel()
+
+class TimerAction(private val viewModel: MainViewModel) {
+    fun startOrStop() {
+        val timeLimit = viewModel.uiState.value.timer.timeLimit
+        val isRunning = viewModel.uiState.value.timer.isRunning
+
+        if (isRunning) {
+            changeTimerState(false)
+            viewModel.sendEvent(UiEvents.StopTimer)
+        } else {
+            changeTimerState(true)
+            viewModel.sendEvent(UiEvents.StartTimer(timeLimit))
+        }
+    }
+
+    fun setTimeLimit(time: Long) {
+        val isTimerRunning = viewModel.uiState.value.timer.isRunning
+        if (isTimerRunning) return
+
+        viewModel.updateState {
+            it.copy(
+                timer =
+                    it.timer.copy(
+                        timeLimit = time,
+                        timeRemaining = time,
+                    ),
+            )
+        }
+    }
+
+    fun displayDialog(visible: Boolean) {
+        val isTimerRunning = viewModel.uiState.value.timer.isRunning
+        if (isTimerRunning) return
+
+        viewModel.updateState {
+            it.copy(timer = it.timer.copy(isDialogVisible = visible))
+        }
+    }
+
+    fun updateTimer(remainingTime: Int) {
+        viewModel.updateState {
+            it.copy(timer = it.timer.copy(timeRemaining = remainingTime.toLong()))
+        }
+    }
+
+    private fun changeTimerState(isRunning: Boolean) {
+        viewModel.updateState {
+            it.copy(timer = it.timer.copy(isRunning = isRunning))
+        }
+    }
+}

--- a/app/src/main/java/io/github/hanihashemi/tomaten/ui/actions/Actions.kt
+++ b/app/src/main/java/io/github/hanihashemi/tomaten/ui/actions/Actions.kt
@@ -50,9 +50,9 @@ class TimerAction(private val viewModel: MainViewModel) {
         }
     }
 
-    fun updateTimer(remainingTime: Int) {
+    fun updateTimer(remainingTime: Long) {
         viewModel.updateState {
-            it.copy(timer = it.timer.copy(timeRemaining = remainingTime.toLong()))
+            it.copy(timer = it.timer.copy(timeRemaining = remainingTime))
         }
     }
 

--- a/app/src/main/java/io/github/hanihashemi/tomaten/ui/events/UiEvents.kt
+++ b/app/src/main/java/io/github/hanihashemi/tomaten/ui/events/UiEvents.kt
@@ -2,4 +2,10 @@ package io.github.hanihashemi.tomaten.ui.events
 
 sealed interface UiEvents {
     data object Login : UiEvents
+
+    data object StopTimer : UiEvents
+
+    data class StartTimer(
+        val timeLimit: Long,
+    ) : UiEvents
 }

--- a/app/src/main/java/io/github/hanihashemi/tomaten/ui/states/UiState.kt
+++ b/app/src/main/java/io/github/hanihashemi/tomaten/ui/states/UiState.kt
@@ -4,6 +4,7 @@ import io.github.hanihashemi.tomaten.User
 
 data class UIState(
     val login: LoginUiState = LoginUiState(),
+    val timer: TimerUiState = TimerUiState(),
 )
 
 data class LoginUiState(
@@ -18,3 +19,10 @@ data class LoginUiState(
     val isLoggedIn: Boolean
         get() = user != null
 }
+
+data class TimerUiState(
+    val isRunning: Boolean = false,
+    val timeRemaining: Long = 15 * 60,
+    val timeLimit: Long = 15 * 60,
+    val isDialogVisible: Boolean = false,
+)


### PR DESCRIPTION
## Summary
- Add foreground timer service for background operation
- Implement notification permissions handling  
- Create timer extensions for formatting utilities
- Update UI to integrate with timer service
- Add proper Android manifest permissions

## Test plan
- [ ] Test timer start/stop functionality
- [ ] Verify notifications appear during timer
- [ ] Test notification permission flow on Android 13+
- [ ] Verify timer continues in background
- [ ] Test completion notification

🤖 Generated with [Claude Code](https://claude.ai/code)