### PR TITLE
Implement dynamic timer-based emote logic for Tomi character

### DIFF
--- a/app/src/main/java/io/github/hanihashemi/tomaten/ui/screens/main/MainScreen.kt
+++ b/app/src/main/java/io/github/hanihashemi/tomaten/ui/screens/main/MainScreen.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.widthIn
@@ -12,6 +11,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -35,6 +35,7 @@ import io.github.hanihashemi.tomaten.ui.dialogs.login.LoginDialog
 import io.github.hanihashemi.tomaten.ui.screens.main.components.Tomi
 import io.github.hanihashemi.tomaten.ui.screens.main.components.TomiEmotes
 import io.github.hanihashemi.tomaten.ui.screens.main.components.TopBar
+import kotlinx.coroutines.delay
 import org.koin.androidx.compose.koinViewModel
 
 @Suppress("FunctionName")
@@ -47,7 +48,26 @@ fun MainScreen(
     val actions = viewModel.actions
 
     var emote by remember { mutableStateOf<TomiEmotes>(TomiEmotes.Smile) }
-    var isZoomed by remember { mutableStateOf(false) }
+    var isZoomed = uiState.timer.isRunning
+    var hasTimerStarted by remember { mutableStateOf(false) }
+
+    // Handle emote changes based on timer state
+    LaunchedEffect(uiState.timer.isRunning) {
+        if (uiState.timer.isRunning) {
+            hasTimerStarted = true
+            emote = TomiEmotes.Smile
+        }
+    }
+
+    // Handle sad emote when timer stops incomplete
+    LaunchedEffect(uiState.timer.isRunning, uiState.timer.timeRemaining) {
+        if (hasTimerStarted && !uiState.timer.isRunning && uiState.timer.timeRemaining > 0) {
+            // Timer stopped but not completed (incomplete)
+            emote = TomiEmotes.Sad
+            delay(5000) // Wait 5 seconds
+            emote = TomiEmotes.Neutral
+        }
+    }
 
     Scaffold(
         modifier = Modifier.fillMaxSize(),
@@ -105,22 +125,6 @@ fun MainScreen(
                     emote = emote,
                     isZoomed = isZoomed,
                 )
-
-                Row {
-                    Button("Toggle Zoom") {
-                        isZoomed = !isZoomed
-                    }
-                    Button("Smile") {
-                        emote = TomiEmotes.Smile
-                    }
-                    Button("Neutral") {
-                        emote = TomiEmotes.Neutral
-                    }
-                    Button("Sad") {
-                        emote = TomiEmotes.Sad
-                    }
-                    Button("Surprise") { emote = TomiEmotes.Surprise }
-                }
             }
         }
 

--- a/app/src/main/java/io/github/hanihashemi/tomaten/ui/screens/main/MainScreen.kt
+++ b/app/src/main/java/io/github/hanihashemi/tomaten/ui/screens/main/MainScreen.kt
@@ -1,19 +1,20 @@
 package io.github.hanihashemi.tomaten.ui.screens.main
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.widthIn
-import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Info
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
@@ -205,25 +206,20 @@ fun MainScreen(
                 }
             }
 
-            // Stats button in bottom right corner with darker background
-            Row(
+            // Stats button in bottom right corner as circular FAB
+            FloatingActionButton(
+                onClick = { onNavigateToStats() },
                 modifier =
                     Modifier
                         .align(Alignment.BottomEnd)
-                        .padding(16.dp)
-                        .background(
-                            color = MaterialTheme.colorScheme.surface.copy(alpha = 0.9f),
-                            shape = RoundedCornerShape(8.dp),
-                        )
-                        .padding(8.dp),
-                horizontalArrangement = Arrangement.End,
+                        .padding(16.dp),
+                containerColor = MaterialTheme.colorScheme.surface.copy(alpha = 0.9f),
+                contentColor = MaterialTheme.colorScheme.onSurface,
             ) {
-                Button(
-                    text = "Stats",
-                    style = ButtonStyles.Secondary,
-                ) {
-                    onNavigateToStats()
-                }
+                Icon(
+                    imageVector = Icons.Filled.Info,
+                    contentDescription = "Stats",
+                )
             }
         }
 

--- a/app/src/main/java/io/github/hanihashemi/tomaten/ui/screens/main/MainScreen.kt
+++ b/app/src/main/java/io/github/hanihashemi/tomaten/ui/screens/main/MainScreen.kt
@@ -1,16 +1,19 @@
 package io.github.hanihashemi.tomaten.ui.screens.main
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
@@ -167,12 +170,6 @@ fun MainScreen(
                     ) {
                         actions.tag.showSelectDialog()
                     }
-                    Button(
-                        text = "Stats",
-                        style = ButtonStyles.Secondary,
-                    ) {
-                        onNavigateToStats()
-                    }
 
                     Tomi(
                         modifier = Modifier,
@@ -205,6 +202,27 @@ fun MainScreen(
                                 .padding(horizontal = 16.dp),
                         color = MaterialTheme.colorScheme.primary,
                     )
+                }
+            }
+
+            // Stats button in bottom right corner with darker background
+            Row(
+                modifier =
+                    Modifier
+                        .align(Alignment.BottomEnd)
+                        .padding(16.dp)
+                        .background(
+                            color = MaterialTheme.colorScheme.surface.copy(alpha = 0.9f),
+                            shape = RoundedCornerShape(8.dp),
+                        )
+                        .padding(8.dp),
+                horizontalArrangement = Arrangement.End,
+            ) {
+                Button(
+                    text = "Stats",
+                    style = ButtonStyles.Secondary,
+                ) {
+                    onNavigateToStats()
                 }
             }
         }

--- a/app/src/main/java/io/github/hanihashemi/tomaten/ui/screens/main/MainScreen.kt
+++ b/app/src/main/java/io/github/hanihashemi/tomaten/ui/screens/main/MainScreen.kt
@@ -1,18 +1,25 @@
 package io.github.hanihashemi.tomaten.ui.screens.main
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.slideInHorizontally
+import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Info
+import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.LinearProgressIndicator
@@ -206,20 +213,50 @@ fun MainScreen(
                 }
             }
 
-            // Stats button in bottom right corner as circular FAB
-            FloatingActionButton(
-                onClick = { onNavigateToStats() },
-                modifier =
-                    Modifier
-                        .align(Alignment.BottomEnd)
-                        .padding(16.dp),
-                containerColor = MaterialTheme.colorScheme.surface.copy(alpha = 0.9f),
-                contentColor = MaterialTheme.colorScheme.onSurface,
+            // Settings and Stats buttons in bottom right corner (slide to right when hiding)
+            AnimatedVisibility(
+                visible = !uiState.timer.isRunning,
+                enter =
+                    slideInHorizontally(
+                        initialOffsetX = { fullWidth -> fullWidth },
+                        animationSpec = tween(300),
+                    ),
+                exit =
+                    slideOutHorizontally(
+                        targetOffsetX = { fullWidth -> fullWidth },
+                        animationSpec = tween(300),
+                    ),
+                modifier = Modifier.align(Alignment.BottomEnd),
             ) {
-                Icon(
-                    imageVector = Icons.Filled.Info,
-                    contentDescription = "Stats",
-                )
+                Row(
+                    modifier = Modifier.padding(16.dp),
+                    horizontalArrangement = Arrangement.spacedBy(12.dp),
+                ) {
+                    // Stats button
+                    FloatingActionButton(
+                        onClick = { onNavigateToStats() },
+                        modifier = Modifier.size(48.dp),
+                        containerColor = MaterialTheme.colorScheme.surface.copy(alpha = 0.9f),
+                        contentColor = MaterialTheme.colorScheme.onSurface,
+                    ) {
+                        Icon(
+                            imageVector = Icons.Filled.Info,
+                            contentDescription = "Stats",
+                        )
+                    }
+                    // Settings button
+                    FloatingActionButton(
+                        onClick = { /* TODO: Add settings navigation */ },
+                        modifier = Modifier.size(48.dp),
+                        containerColor = MaterialTheme.colorScheme.surface.copy(alpha = 0.9f),
+                        contentColor = MaterialTheme.colorScheme.onSurface,
+                    ) {
+                        Icon(
+                            imageVector = Icons.Filled.Settings,
+                            contentDescription = "Settings",
+                        )
+                    }
+                }
             }
         }
 

--- a/app/src/main/java/io/github/hanihashemi/tomaten/ui/screens/main/MainScreen.kt
+++ b/app/src/main/java/io/github/hanihashemi/tomaten/ui/screens/main/MainScreen.kt
@@ -87,7 +87,8 @@ fun MainScreen(
                 holdProgress = (elapsed / 2000f).coerceIn(0f, 1f)
                 delay(16) // ~60fps updates
             }
-            if (isHolding && holdProgress >= 1f) {
+            // Check if we completed the full 2 seconds while still holding
+            if (isHolding && System.currentTimeMillis() - startTime >= 2000) {
                 // Stop timer after 2 seconds of holding
                 actions.timer.startOrStop()
                 isHolding = false

--- a/app/src/main/java/io/github/hanihashemi/tomaten/ui/screens/main/components/Tomi.kt
+++ b/app/src/main/java/io/github/hanihashemi/tomaten/ui/screens/main/components/Tomi.kt
@@ -42,6 +42,8 @@ fun Tomi(
     modifier: Modifier,
     emote: TomiEmotes,
     isZoomed: Boolean,
+    onPress: () -> Unit = {},
+    onRelease: () -> Unit = {},
 ) {
     val context = LocalContext.current
     val state = rememberTomiState()
@@ -173,6 +175,7 @@ fun Tomi(
                 .pointerInput(Unit) {
                     detectTapGestures(
                         onPress = {
+                            onPress()
                             coroutineScope.launch {
                                 // Press down animation
                                 state.scale.animateTo(0.98f, tween(100))
@@ -182,6 +185,7 @@ fun Tomi(
                                 // Wait for release
                                 awaitRelease()
 
+                                onRelease()
                                 // Release bounce animation
                                 coroutineScope.launch {
                                     state.scale.animateTo(1.08f, tween(100))
@@ -190,6 +194,7 @@ fun Tomi(
                                 }
                             } catch (e: Exception) {
                                 // Handle cancelled press (e.g. dragged out of bounds)
+                                onRelease()
                                 coroutineScope.launch {
                                     state.scale.animateTo(1f, tween(100))
                                 }


### PR DESCRIPTION
## Summary
- Implements dynamic emote changes based on timer state for better user experience
- Smile emote when timer starts to indicate active session
- Sad emote for 5 seconds when timer stops incomplete, then transitions to neutral
- Default emote is smile on app startup for welcoming experience
- Removes manual emote control buttons as they're no longer needed with automatic logic

## Changes
- Added `LaunchedEffect` blocks to monitor timer state changes
- Introduced `hasTimerStarted` flag to prevent sad emote on app startup
- Cleaned up unused imports and simplified zoom logic
- Removed manual emote control buttons from UI

## Test plan
- [ ] Verify app starts with smile emote
- [ ] Start timer and confirm emote changes to smile
- [ ] Stop timer before completion and verify sad emote shows for 5 seconds
- [ ] Confirm emote transitions to neutral after sad timeout
- [ ] Test timer completion (let it reach 0) and verify emote behavior

🤖 Generated with [Claude Code](https://claude.ai/code)